### PR TITLE
fix: avoid using a reserved variable name

### DIFF
--- a/autoload/snipewin/callback.vim
+++ b/autoload/snipewin/callback.vim
@@ -25,9 +25,9 @@ function! snipewin#callback#swap(winid) abort
     wincmd x
     return
   endif
-  let count = s:find_wincmd_x_target(winlayout(), current, a:winid)
-  if count
-    execute count 'wincmd x'
+  let target = s:find_wincmd_x_target(winlayout(), current, a:winid)
+  if target
+    execute target 'wincmd x'
     return
   endif
   let current = winbufnr(current)


### PR DESCRIPTION
In Vim, `count` is a reserved variable name and `let` will cause an error.

```
:let count = 0

E46: 読取専用変数 "count" には値を設定できません
```